### PR TITLE
cicd: add Docker image and deploy to fly.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+# Version control
+.git
+.gitignore
+
+# Node.js (if applicable)
+node_modules
+npm-debug.log
+
+# Python (if applicable)
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+pip-log.txt
+pip-delete-this-directory.txt
+
+# IDEs and editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Build outputs
+dist/
+build/
+*.egg-info/
+
+# Logs
+*.log
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Docker
+Dockerfile
+docker-compose.yml
+
+# Other
+*.md
+LICENSE

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,19 @@
+# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group # optional: ensure only one action runs at a time
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.22 as builder
+
+# FROM golang:1.22-alpine as builder
+# RUN apk update && apk upgrade && apk add --no-cache make
+
+COPY ./ /app
+
+WORKDIR /app
+
+RUN make test && make build
+
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=builder /app/build /app
+
+CMD [ "./app/http" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ FROM alpine:latest
 
 WORKDIR /app
 
-COPY --from=builder /app/build /app
+# run as regular, non-root user
+RUN addgroup -S app && adduser -S app -G app
+USER app
 
-CMD [ "./app/http" ]
+COPY --from=builder /app/build/ /app/
+
+CMD [ "/app/http" ]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ vendor:
 	go mod tidy && go mod vendor
 
 build:
-	go build -o build/http ./app/cmd/
+	CGO_ENABLED=0 go build  -ldflags \
+		"-w -s" \
+		-o build/http \
+		-tags netgo \
+		-a ./app/cmd/
 
 test:
 	go test -v ./...

--- a/app/http/handlers.go
+++ b/app/http/handlers.go
@@ -80,6 +80,6 @@ func (h *httpHandler) PostSubscribeAddress(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *httpHandler) HandleHealthCheck(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("OK"))
 	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+  app:
+    image: tx-parser-go:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+      platforms:
+        - linux/amd64
+    environment:
+      PORT: 8080
+      PUBLIC_NODE_URL: https://ethereum-rpc.publicnode.com/
+      START_BLOCK: 21337490
+      JOB_SCHEDULE: 1s
+    ports:
+      - "8080:8080"

--- a/fly.toml
+++ b/fly.toml
@@ -19,7 +19,7 @@ processes = ['app']
 [env]
 PUBLIC_NODE_URL = "https://ethereum-rpc.publicnode.com/"
 PORT = "8080"
-START_BLOCK = "21292394"
+START_BLOCK = "21337490"
 JOB_SCHEDULE = "1s"
 
 [[vm]]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,38 @@
+# fly.toml app configuration file generated for tx-parser-go on 2024-12-05T23:26:21+08:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'tx-parser-go'
+primary_region = 'hkg'
+
+[build]
+
+[http_service]
+internal_port = 8080
+force_https = true
+auto_stop_machines = 'stop'
+auto_start_machines = true
+min_machines_running = 0
+processes = ['app']
+
+[env]
+PUBLIC_NODE_URL = "https://ethereum-rpc.publicnode.com/"
+PORT = "8080"
+START_BLOCK = "21292394"
+JOB_SCHEDULE = "1s"
+
+[[vm]]
+memory = '1gb'
+cpu_kind = 'shared'
+cpus = 1
+
+[checks]
+[checks.http_health_check]
+port = 8080
+type = 'http'
+interval = '15s'
+timeout = '10s'
+grace_period = '30s'
+method = 'get'
+path = '/healthz'


### PR DESCRIPTION
- added standard .dockerignore entries
- Dockerfile to prepare for containerization
- fly.io deployment scripts