### PR TITLE
fix: initially fetch latest block to prevent too many goroutines

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
 jobs:
   deploy:
     name: Deploy app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ WORKDIR /app
 
 RUN make test && make build
 
-FROM alpine:latest
+FROM alpine:3.21
+
+RUN apk update && apk upgrade && apk add --no-cache ca-certificates
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ test:
 	go test -v ./...
 
 run-server:
-	PUBLIC_NODE_URL=https://ethereum-rpc.publicnode.com/ PORT=8081 START_BLOCK=21292394 JOB_SCHEDULE=1s go run app/cmd/main.go
+	PUBLIC_NODE_URL=https://ethereum-rpc.publicnode.com/ PORT=8080 JOB_SCHEDULE=1s go run app/cmd/main.go
 
 run-build: build
-	PUBLIC_NODE_URL=https://ethereum-rpc.publicnode.com/ PORT=8081 START_BLOCK=21292394 JOB_SCHEDULE=1s ./build/http
+	PUBLIC_NODE_URL=https://ethereum-rpc.publicnode.com/ PORT=8080 JOB_SCHEDULE=1s ./build/http
 
 run-client:
-	PARSER_URL=http://localhost:8081 fetchFrequency=10s SUBSCRIBE_ADDRESSES="0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5,0x6eaE5e2d47f1CbB5979734812521579921d37C9A" go run client/cmd/main.go
+	PARSER_URL=http://localhost:8080 FETCH_FREQUENCY=10s SUBSCRIBE_ADDRESSES="0xdAC17F958D2ee523a2206206994597C13D831ec7,0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" go run client/cmd/main.go
 
 # doesn't work because run-server doesn't exit
 # run: run-server run-client

--- a/app/cmd/main.go
+++ b/app/cmd/main.go
@@ -62,7 +62,7 @@ func main() {
 	go func() {
 		logger.Println("starting the parser worker")
 
-		if err := parser.Run(ctx, config.startBlock, config.jobSchedule); err != nil && !errors.Is(err, context.Canceled) {
+		if err := parser.Run(ctx, config.jobSchedule); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Fatalf("failed to run parser: %v", err)
 		}
 
@@ -87,7 +87,6 @@ func main() {
 type Config struct {
 	publicNodeURL string
 	port          int64
-	startBlock    int64
 	jobSchedule   time.Duration
 }
 
@@ -95,7 +94,6 @@ func NewConfig() *Config {
 	return &Config{
 		publicNodeURL: env.GetEnv("PUBLIC_NODE_URL", "https://ethereum-rpc.publicnode.com/"),
 		port:          env.GetEnvInt64("PORT", 8080),
-		startBlock:    env.GetEnvInt64("START_BLOCK", 21292394),
 		jobSchedule:   env.GetEnvDuration("JOB_SCHEDULE", 5*time.Second),
 	}
 }

--- a/app/worker/parser.go
+++ b/app/worker/parser.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -28,8 +29,14 @@ func NewParserWorker(blockchain blockchain.BlockchainClient, repo repository.Rep
 }
 
 // Run method with improved concurrency and error handling
-func (p *ParserWorker) Run(ctx context.Context, startBlock int64, schedule time.Duration) error {
-	lastParsedBlock := startBlock
+func (p *ParserWorker) Run(ctx context.Context, schedule time.Duration) error {
+	// fetch latest block number first
+	// if it fails, return the error so it will handle the recovery sequence
+	lastParsedBlock, err := p.blockchain.GetLatestBlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get latest block number: %w", err)
+	}
+
 	// If the context is cancelled, exit immediately
 	for {
 		select {


### PR DESCRIPTION
- cleanup config
- use USDT and WBTC as test addresses
- fixes a bug caused by static initial block config value and sprawled too much goroutines (initial block - latest block)
- refactored to fetch the initial latest block instead of a static value